### PR TITLE
Update channel.py

### DIFF
--- a/realtime/channel.py
+++ b/realtime/channel.py
@@ -52,7 +52,7 @@ class Channel:
         :return: None
         """
         join_req = dict(topic=self.topic, event="phx_join",
-                        payload={}, ref=None)
+                        payload=self.params, ref=None)
 
         try:
             await self.socket.ws_connection.send(json.dumps(join_req))


### PR DESCRIPTION
joining a channel should send the params

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

the params dict, if given in Socket(), is not used when joining a channel - an empty dict is sent instead.

## What is the new behavior?

The params dict, if given, is used when joining a channel.
If params is not given in Socket(), then the behaviour is the same as before - an empty dict


