### PR TITLE
Cleanout

### DIFF
--- a/realtime/_async/channel.py
+++ b/realtime/_async/channel.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import asyncio
 import json
 import logging

--- a/realtime/_sync/channel.py
+++ b/realtime/_sync/channel.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from typing import TYPE_CHECKING
 
 from realtime.types import RealtimeChannelOptions


### PR DESCRIPTION
## What kind of change does this PR introduce?

- Cleanout future imports `from __future__ import annotations` no longer needed for Python >= `3.9.0`.
