### PR TITLE
fix: change set auth to sync method

### DIFF
--- a/realtime/_async/client.py
+++ b/realtime/_async/client.py
@@ -243,7 +243,7 @@ class AsyncRealtimeClient:
         for topic, channel in self.channels.items():
             print(f"Topic: {topic} | Events: {[e for e, _ in channel.listeners]}]")
 
-    async def set_auth(self, token: Union[str, None]) -> None:
+    def set_auth(self, token: Union[str, None]) -> None:
         """
         Set the authentication token for the connection and update all joined channels.
 
@@ -260,7 +260,9 @@ class AsyncRealtimeClient:
 
         for _, channel in self.channels.items():
             if channel._joined_once and channel.is_joined:
-                await channel.push(ChannelEvents.access_token, {"access_token": token})
+                asyncio.create_task(
+                    channel.push(ChannelEvents.access_token, {"access_token": token})
+                )
 
     def _make_ref(self) -> str:
         self.ref += 1

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -49,7 +49,7 @@ async def access_token() -> str:
 async def test_set_auth(socket: AsyncRealtimeClient):
     await socket.connect()
 
-    await socket.set_auth("jwt")
+    socket.set_auth("jwt")
     assert socket.access_token == "jwt"
 
     await socket.close()
@@ -104,7 +104,7 @@ async def test_postgrest_changes(socket: AsyncRealtimeClient):
     await socket.connect()
     listen_task = asyncio.create_task(socket.listen())
 
-    await socket.set_auth(token)
+    socket.set_auth(token)
 
     channel: AsyncRealtimeChannel = socket.channel("test-postgres-changes")
     received_events = {"all": [], "insert": [], "update": [], "delete": []}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix.

## What is the current behavior?

`set_auth` is called async but this won't work when used with `supabase-py` because the auth change event happens in a sync method.

## What is the new behavior?

`set_auth` is called sync and the auth change event can use the sync method.

## Additional context

Add any other context or screenshots.
