### PR TITLE
fix: update broken method calls

### DIFF
--- a/realtime/_async/channel.py
+++ b/realtime/_async/channel.py
@@ -95,7 +95,7 @@ class AsyncRealtimeChannel:
             logging.info(f"channel {self.topic} closed")
             self.rejoin_timer.reset()
             self.state = ChannelStates.CLOSED
-            self.socket._remove(self)
+            self.socket.remove_channel(self)
 
         def on_error(payload, *args):
             if self.is_leaving or self.is_closed:
@@ -290,11 +290,11 @@ class AsyncRealtimeChannel:
         :return: Channel
         """
         try:
-            await self.socket._send(
+            await self.socket.send(
                 {
                     "topic": self.topic,
                     "event": "phx_join",
-                    "payload": {"config": self.channel_params},
+                    "payload": {"config": self.params},
                     "ref": None,
                 }
             )

--- a/realtime/_async/client.py
+++ b/realtime/_async/client.py
@@ -94,7 +94,7 @@ class AsyncRealtimeClient:
             except websockets.exceptions.ConnectionClosed:
                 if self.auto_reconnect:
                     logger.info("Connection with server closed, trying to reconnect...")
-                    await self._connect()
+                    await self.connect()
                     for topic, channel in self.channels.items():
                         await channel.join()
                 else:
@@ -190,7 +190,7 @@ class AsyncRealtimeClient:
             except websockets.exceptions.ConnectionClosed:
                 if self.auto_reconnect:
                     logger.info("Connection with server closed, trying to reconnect...")
-                    await self._connect()
+                    await self.connect()
                 else:
                     logger.exception("Connection with the server closed.")
                     break


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Auto reconnect is broken, because a non-existing method is called (`_connect`)

## What is the new behavior?

Call the correct method (`connect`)