### PR TITLE
chore: adding a logger masking filter

### DIFF
--- a/realtime/_async/channel.py
+++ b/realtime/_async/channel.py
@@ -15,7 +15,7 @@ from realtime.types import (
     RealtimePresenceState,
     RealtimeSubscribeStates,
 )
-
+from ..logging_util import TokenMaskingFilter
 from ..transformers import http_endpoint_url
 from .presence import (
     AsyncRealtimePresence,
@@ -29,7 +29,7 @@ if TYPE_CHECKING:
     from .client import AsyncRealtimeClient
 
 logger = logging.getLogger(__name__)
-
+logger.addFilter(TokenMaskingFilter())
 
 class AsyncRealtimeChannel:
     """

--- a/realtime/_async/channel.py
+++ b/realtime/_async/channel.py
@@ -15,6 +15,7 @@ from realtime.types import (
     RealtimePresenceState,
     RealtimeSubscribeStates,
 )
+
 from ..logging_util import TokenMaskingFilter
 from ..transformers import http_endpoint_url
 from .presence import (
@@ -30,6 +31,7 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 logger.addFilter(TokenMaskingFilter())
+
 
 class AsyncRealtimeChannel:
     """

--- a/realtime/_async/client.py
+++ b/realtime/_async/client.py
@@ -8,6 +8,7 @@ from typing import Any, Callable, Dict, List, Optional
 import websockets
 
 from ..exceptions import NotConnectedError
+from ..logging_util import TokenMaskingFilter
 from ..message import Message
 from ..transformers import http_endpoint_url
 from ..types import (
@@ -21,7 +22,7 @@ from ..types import (
 from .channel import AsyncRealtimeChannel, RealtimeChannelOptions
 
 logger = logging.getLogger(__name__)
-
+logger.addFilter(TokenMaskingFilter())
 
 def ensure_connection(func: Callback):
     @wraps(func)

--- a/realtime/_async/client.py
+++ b/realtime/_async/client.py
@@ -125,7 +125,7 @@ class AsyncRealtimeClient:
 
         while retries < self.max_retries:
             try:
-                self.ws_connection = await websockets.connect(self.url)
+                self.ws_connection = await websockets.connect(self.url, logger=logger)
                 if self.ws_connection.open:
                     logger.info("Connection was successful")
                     return await self._on_connect()

--- a/realtime/_async/client.py
+++ b/realtime/_async/client.py
@@ -24,6 +24,7 @@ from .channel import AsyncRealtimeChannel, RealtimeChannelOptions
 logger = logging.getLogger(__name__)
 logger.addFilter(TokenMaskingFilter())
 
+
 def ensure_connection(func: Callback):
     @wraps(func)
     def wrapper(*args: T_ParamSpec.args, **kwargs: T_ParamSpec.kwargs) -> T_Retval:

--- a/realtime/_async/push.py
+++ b/realtime/_async/push.py
@@ -2,13 +2,14 @@ import asyncio
 import logging
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
+from ..logging_util import TokenMaskingFilter
 from ..types import DEFAULT_TIMEOUT, Callback, _Hook
 
 if TYPE_CHECKING:
     from .channel import AsyncRealtimeChannel
 
 logger = logging.getLogger(__name__)
-
+logger.addFilter(TokenMaskingFilter())
 
 class AsyncPush:
     def __init__(

--- a/realtime/_async/push.py
+++ b/realtime/_async/push.py
@@ -11,6 +11,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 logger.addFilter(TokenMaskingFilter())
 
+
 class AsyncPush:
     def __init__(
         self,

--- a/realtime/logging_util.py
+++ b/realtime/logging_util.py
@@ -1,0 +1,19 @@
+import logging
+import re
+
+redact = r"(eyJh\w*\.)(\w*)\."
+
+class TokenMaskingFilter(logging.Filter):
+    """Mask access_tokens in logs"""
+
+    def filter(self, record):
+        record.msg = self.sanitize_line(record.msg)
+        return True
+
+    @staticmethod
+    def sanitize_line(line):
+        def gred(g):
+            """Redact the payload of the JWT, keeping the header and signature"""
+            return f"{g.group(1)}REDACTED." if len(g.groups()) > 1 else g
+
+        return re.sub(redact, gred, line)

--- a/realtime/logging_util.py
+++ b/realtime/logging_util.py
@@ -3,6 +3,7 @@ import re
 
 redact = r"(eyJh\w*\.)(\w*)\."
 
+
 class TokenMaskingFilter(logging.Filter):
     """Mask access_tokens in logs"""
 

--- a/realtime/logging_util.py
+++ b/realtime/logging_util.py
@@ -1,3 +1,4 @@
+import copy
 import logging
 import re
 
@@ -8,17 +9,35 @@ import re
 redact = r"(eyJh[-_\w]*\.)([-_\w]*)\."
 
 
+def gred(g):
+    """Redact the payload of the JWT, keeping the header and signature"""
+    return f"{g.group(1)}REDACTED." if len(g.groups()) > 1 else g
+
+
 class TokenMaskingFilter(logging.Filter):
     """Mask access_tokens in logs"""
 
     def filter(self, record):
         record.msg = self.sanitize_line(record.msg)
+        record.args = self.sanitize_args(record.args)
         return True
 
     @staticmethod
-    def sanitize_line(line):
-        def gred(g):
-            """Redact the payload of the JWT, keeping the header and signature"""
-            return f"{g.group(1)}REDACTED." if len(g.groups()) > 1 else g
+    def sanitize_args(d):
+        if isinstance(d, dict):
+            d = d.copy()  # so we don't overwrite anything
+            for k, v in d.items():
+                d[k] = self.sanitize_line(v)
+        elif isinstance(d, tuple):
+            # need a deepcopy of tuple turned to a list, as to not change the original values
+            # otherwise we end up changing the items at the original memory location of the passed in tuple
+            y = copy.deepcopy(list(d))
+            for x, value in enumerate(y):
+                if isinstance(value, str):
+                    y[x] = re.sub(redact, gred, value)
+            return tuple(y)  # convert the list back to a tuple
+        return d
 
+    @staticmethod
+    def sanitize_line(line):
         return re.sub(redact, gred, line)

--- a/realtime/logging_util.py
+++ b/realtime/logging_util.py
@@ -1,7 +1,11 @@
 import logging
 import re
 
-redact = r"(eyJh\w*\.)(\w*)\."
+# redaction regex for detecting JWT tokens
+# <header>.<payload>.<signature>
+# character set [a-zA-Z0-9_-]
+# \w covers [a-zA-Z0-9]
+redact = r"(eyJh[-_\w]*\.)([-_\w]*)\."
 
 
 class TokenMaskingFilter(logging.Filter):


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix / feature

## What is the current behavior?

INFO log lines may contain the access_token jwt

## What is the new behavior?

Use a `logging.Filter` to redact JWT tokens that may be in log messages.
JWT's will be displayed as `eyJh.REDACTED.2j7_78f` where `eyJh` would be the full header and `2j7_78f` would be the full signature.

```bash
$ python3 app.py                                                                                                                                                                                                                                                                                                                
2024-10-01 12:44:53,590:INFO - Connection was successful
2024-10-01 12:44:53,777:INFO - Connection was successful
2024-10-01 12:44:53,778:INFO - send: {"topic": "realtime:test-broadcast", "event": "phx_join", "payload": {"config": {"broadcast": {"self": true}, "presence": {"key": ""}, "private": false, "postgres_changes": []}, "access_token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.REDACTED.2j7_78fvwrR3Ok3zTWOrPmS4HgvAY8xWpMdTM7MX-bg"}, "ref": "1", "join_ref": "1"}
2024-10-01 12:44:54,780:INFO - send: {"topic": "realtime:test-broadcast", "event": "broadcast", "payload": {"type": "broadcast", "event": "test-event", "payload": {"message": "Event 1"}}, "ref": "2", "join_ref": "1"}
2024-10-01 12:44:54,781:INFO - send: {"topic": "realtime:test-broadcast", "event": "broadcast", "payload": {"type": "broadcast", "event": "test-event", "payload": {"message": "Event 2"}}, "ref": "3", "join_ref": "1"}
```

## Additional context

~Doesn't address the fact that logging set to `DEBUG` will have the JWT in the connection log line created by `websockets`.~
Websocket DEBUG logs are also redacted after adding https://github.com/supabase/realtime-py/pull/217/commits/053221bf99e5dd47e0c8dd0cb4d21b84801acb5b

