### PR TITLE
fix: prevent sending expired tokens

### DIFF
--- a/realtime/_async/client.py
+++ b/realtime/_async/client.py
@@ -259,6 +259,7 @@ class AsyncRealtimeClient:
         Returns:
             None
         """
+        # No empty string tokens.
         if isinstance(token, str) and len(token.strip()) == 0:
             raise ValueError("Provide a valid jwt token")
 
@@ -271,6 +272,7 @@ class AsyncRealtimeClient:
                 raise ValueError("InvalidJWTToken")
 
             if parsed:
+                # Handle expired token if any.
                 if "exp" in parsed:
                     now = floor(datetime.now().timestamp())
                     valid = now - parsed["exp"] < 0

--- a/realtime/_async/client.py
+++ b/realtime/_async/client.py
@@ -259,26 +259,27 @@ class AsyncRealtimeClient:
         Returns:
             None
         """
-        # No empty string tokens.
         if isinstance(token, str) and len(token.strip()) == 0:
-            raise ValueError("InvalidJWTToken: Provide a valid jwt token")
+            raise ValueError("Provide a valid jwt token")
 
         if token:
-            payload = token.split(".")[1] + "=="
             parsed = None
             try:
+                payload = token.split(".")[1] + "=="
                 parsed = json.loads(b64decode(payload).decode("utf-8"))
             except Exception:
-                raise ValueError("InvalidJWTToken: Provide a valid jwt token")
+                raise ValueError("InvalidJWTToken")
 
-            # Handle expired token if any.
-            if parsed and "exp" in parsed:
-                now = floor(datetime.now().timestamp())
-                valid = now - parsed["exp"] < 0
-                if not valid:
-                    raise ValueError(
-                        f"InvalidJWTToken: Invalid value for JWT claim 'exp' with value { parsed['exp'] }"
-                    )
+            if parsed:
+                if "exp" in parsed:
+                    now = floor(datetime.now().timestamp())
+                    valid = now - parsed["exp"] < 0
+                    if not valid:
+                        raise ValueError(
+                            f"InvalidJWTToken: Invalid value for JWT claim 'exp' with value { parsed['exp'] }"
+                        )
+                else:
+                    raise ValueError("InvalidJWTToken: expected claim 'exp'")
 
         self.access_token = token
 

--- a/realtime/_async/client.py
+++ b/realtime/_async/client.py
@@ -2,7 +2,6 @@ import asyncio
 import json
 import logging
 import re
-
 from base64 import b64decode
 from datetime import datetime
 from functools import wraps

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -49,8 +49,8 @@ async def access_token() -> str:
 async def test_set_auth(socket: AsyncRealtimeClient):
     await socket.connect()
 
-    await socket.set_auth("jwt")
-    assert socket.access_token == "jwt"
+    with pytest.raises(ValueError):
+        await socket.set_auth("jwt")  # Invalid JWT.
 
     await socket.close()
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

- Do not send expired token.
- Fix #243
- Based but not copied from: https://github.com/supabase/realtime-js/pull/437/files#diff-f5a6b192eb9d6c05f61c33d8629b814ad893fbfb729bfa7af9b226e5c87d2e85R343-R350
