### PR TITLE
chore(example): fix example

### DIFF
--- a/example/supabase/seed.sql
+++ b/example/supabase/seed.sql
@@ -1,0 +1,11 @@
+-- Create a table for holding todos
+CREATE TABLE todos(
+    id uuid PRIMARY KEY DEFAULT uuid_generate_v4(),
+    description text,
+    is_completed boolean DEFAULT FALSE,
+    created_at timestamp with time zone DEFAULT now(),
+    updated_at timestamp with time zone DEFAULT now()
+);
+
+ALTER publication supabase_realtime
+    ADD TABLE todos;


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fix example (#257):
- Added example seed, which was missing completely
- `test_broadcast_events` was missing `socket.listen` call, thus failing
- `test_postgres_changes` had the wrong filter as id is a UUID and not an int
- `test_postgres_changes` was blocking, which it should not have been
- Added INSERT, UPDATE and DELETE calls in `test_postgres_changes` to actually see realtime trigger

## What is the current behavior?

`test_broadcast_events` and `test_postgres_changes` don't work

## What is the new behavior?

`test_broadcast_events` and `test_postgres_changes` work
