### PR TITLE
fix: send correct payload to channel on reconnect

### DIFF
--- a/realtime/_async/client.py
+++ b/realtime/_async/client.py
@@ -101,10 +101,8 @@ class AsyncRealtimeClient:
                 if self.auto_reconnect:
                     logger.info("Connection with server closed, trying to reconnect...")
                     await self.connect()
-                    if self.access_token:
-                        await self.set_auth(self.access_token)
                     for topic, channel in self.channels.items():
-                        await channel.join()
+                        await channel._rejoin()
                 else:
                     logger.exception("Connection with the server closed.")
                     break

--- a/realtime/_async/client.py
+++ b/realtime/_async/client.py
@@ -101,6 +101,8 @@ class AsyncRealtimeClient:
                 if self.auto_reconnect:
                     logger.info("Connection with server closed, trying to reconnect...")
                     await self.connect()
+                    if self.access_token:
+                        await self.set_auth(self.access_token)
                     for topic, channel in self.channels.items():
                         await channel.join()
                 else:


### PR DESCRIPTION
## What kind of change does this PR introduce?
I think it should fix #258 

## What is the current behavior?

When `auto_reconnect` is `True`, the channel is attempted to joined but it uses defaul payload which is empty. Instead it should use the existing payload that was originally used when the channel was first joined.
