### PR TITLE
fix: Set default heartbeat interval to 25s

### DIFF
--- a/realtime/_async/client.py
+++ b/realtime/_async/client.py
@@ -15,6 +15,7 @@ from websockets.asyncio.client import ClientConnection, connect
 from ..message import Message
 from ..transformers import http_endpoint_url
 from ..types import (
+    DEFAULT_HEARTBEAT_INTERVAL,
     DEFAULT_TIMEOUT,
     PHOENIX_CHANNEL,
     VSN,
@@ -43,7 +44,7 @@ class AsyncRealtimeClient:
         token: Optional[str] = None,
         auto_reconnect: bool = True,
         params: Optional[Dict[str, Any]] = None,
-        hb_interval: int = 30,
+        hb_interval: int = DEFAULT_HEARTBEAT_INTERVAL,
         max_retries: int = 5,
         initial_backoff: float = 1.0,
         timeout: int = DEFAULT_TIMEOUT,
@@ -56,7 +57,7 @@ class AsyncRealtimeClient:
         :param token: Authentication token for the WebSocket connection.
         :param auto_reconnect: If True, automatically attempt to reconnect on disconnection. Defaults to True.
         :param params: Optional parameters for the connection. Defaults to None.
-        :param hb_interval: Interval (in seconds) for sending heartbeat messages to keep the connection alive. Defaults to 30.
+        :param hb_interval: Interval (in seconds) for sending heartbeat messages to keep the connection alive. Defaults to 25.
         :param max_retries: Maximum number of reconnection attempts. Defaults to 5.
         :param initial_backoff: Initial backoff time (in seconds) for reconnection attempts. Defaults to 1.0.
         :param timeout: Connection timeout in seconds. Defaults to DEFAULT_TIMEOUT.

--- a/realtime/types.py
+++ b/realtime/types.py
@@ -7,6 +7,7 @@ from typing_extensions import ParamSpec
 DEFAULT_TIMEOUT = 10
 PHOENIX_CHANNEL = "phoenix"
 VSN = "1.0.0"
+DEFAULT_HEARTBEAT_INTERVAL = 25
 
 # Type variables and custom types
 T_ParamSpec = ParamSpec("T_ParamSpec")

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -54,7 +54,7 @@ def test_init_client():
     assert "/websocket" in client.url
     assert client.url.split("apikey=")[1] == ANON_KEY
     assert client.auto_reconnect is True
-    assert client.params is None
+    assert client.params == {}
     assert client.hb_interval == DEFAULT_HEARTBEAT_INTERVAL
     assert client.max_retries == 5
     assert client.initial_backoff == 1.0

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -7,6 +7,7 @@ import pytest
 from dotenv import load_dotenv
 
 from realtime import AsyncRealtimeChannel, AsyncRealtimeClient, RealtimeSubscribeStates
+from realtime.types import DEFAULT_HEARTBEAT_INTERVAL, DEFAULT_TIMEOUT
 
 load_dotenv()
 
@@ -43,6 +44,21 @@ async def access_token() -> str:
                 raise Exception(
                     f"Failed to get access token. Status: {response.status}"
                 )
+
+
+def test_init_client():
+    client = AsyncRealtimeClient(URL, ANON_KEY)
+
+    assert client is not None
+    assert client.url.startswith("ws://") or client.url.startswith("wss://")
+    assert "/websocket" in client.url
+    assert client.url.split("apikey=")[1] == ANON_KEY
+    assert client.auto_reconnect is True
+    assert client.params is None
+    assert client.hb_interval == DEFAULT_HEARTBEAT_INTERVAL
+    assert client.max_retries == 5
+    assert client.initial_backoff == 1.0
+    assert client.timeout == DEFAULT_TIMEOUT
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What kind of change does this PR introduce?

- Sets default heartbeat interval to 25s
- Adds a new test for asserting initialization of client.