### PR TITLE
fix: revert client to handle bc changes

### DIFF
--- a/realtime/_async/client.py
+++ b/realtime/_async/client.py
@@ -10,7 +10,8 @@ from typing import Any, Callable, Dict, List, Optional
 from urllib.parse import urlencode, urlparse, urlunparse
 
 import websockets
-from websockets.asyncio.client import ClientConnection, connect
+from websockets import connect
+from websockets.client import ClientProtocol
 
 from ..message import Message
 from ..transformers import http_endpoint_url
@@ -73,7 +74,7 @@ class AsyncRealtimeClient:
         self.access_token = token
         self.send_buffer: List[Callable] = []
         self.hb_interval = hb_interval
-        self.ws_connection: Optional[ClientConnection] = None
+        self.ws_connection: Optional[ClientProtocol] = None
         self.ref = 0
         self.auto_reconnect = auto_reconnect
         self.channels: Dict[str, AsyncRealtimeChannel] = {}


### PR DESCRIPTION
## What kind of change does this PR introduce?

In the last release it seems we broke usage of older versions of websockets with realtime-py. Some user's rely on this.

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

https://github.com/supabase/supabase/issues/33712
