### PR TITLE
fix: cleanup current heartbeat and listen tasks before creating a new one

### DIFF
--- a/realtime/_async/client.py
+++ b/realtime/_async/client.py
@@ -185,9 +185,16 @@ class AsyncRealtimeClient:
         pass
 
     async def _on_connect(self) -> None:
+        if self._listen_task:
+            self._listen_task.cancel()
+            self._listen_task = None
+
+        if self._heartbeat_task:
+            self._heartbeat_task.cancel()
+            self._heartbeat_task = None
+
         self._listen_task = asyncio.create_task(self._listen())
         self._heartbeat_task = asyncio.create_task(self._heartbeat())
-
         await self._flush_send_buffer()
 
     async def _flush_send_buffer(self):

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -297,6 +297,7 @@ async def test_multiple_connect_attempts(socket: AsyncRealtimeClient):
     assert any(
         msg in error_msg.lower()
         for msg in [
+            "temporary failure in name resolution",
             "nodename nor servname provided",
             "name or service not known",
             "connection refused",

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -252,3 +252,61 @@ async def delete_todo(access_token: str, id: str):
         async with session.delete(url, headers=headers) as response:
             if response.status != 204:
                 raise Exception(f"Failed to delete todo. Status: {response.status}")
+
+
+@pytest.mark.asyncio
+async def test_multiple_connect_attempts(socket: AsyncRealtimeClient):
+    # First connection should succeed
+    await socket.connect()
+    assert socket.is_connected
+    initial_ws = socket.ws_connection
+
+    # Second connection attempt should be a no-op since we're already connected
+    await socket.connect()
+    assert socket.is_connected
+    assert socket.ws_connection == initial_ws  # Should be the same connection object
+
+    await socket.close()
+    assert not socket.is_connected
+
+    # Test connection failure and retry behavior
+    # Temporarily modify the URL to force a connection failure
+    original_url = socket.url
+    socket.url = "ws://invalid-url-that-will-fail:12345/websocket"
+    socket.max_retries = 2  # Reduce retries for faster test
+    socket.initial_backoff = 0.1  # Reduce backoff for faster test
+
+    start_time = datetime.datetime.now()
+
+    with pytest.raises(Exception) as exc_info:
+        await socket.connect()
+
+    end_time = datetime.datetime.now()
+    duration = (end_time - start_time).total_seconds()
+
+    # Should have tried to connect max_retries times with exponential backoff
+    # First attempt: immediate
+    # Second attempt: after 0.1s
+    # Total time should be at least the sum of backoff times but not much more
+    assert duration >= 0.1, "Should have waited for backoff between retries"
+    assert duration < 1.0, "Should not have waited longer than necessary"
+
+    # The error message can vary depending on the system and Python version
+    # Common messages include DNS resolution errors or connection refused
+    error_msg = str(exc_info.value)
+    assert any(
+        msg in error_msg.lower()
+        for msg in [
+            "nodename nor servname provided",
+            "name or service not known",
+            "connection refused",
+            "failed to establish",
+        ]
+    ), f"Unexpected error message: {error_msg}"
+
+    # Restore original URL and verify we can connect again
+    socket.url = original_url
+    await socket.connect()
+    assert socket.is_connected
+
+    await socket.close()


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fix https://github.com/supabase/realtime-py/issues/289

## What is the new behavior?

- Make sure to cleanup current `heartbeat` and `listen` tasks before creating a new one.
- Add tests for verifying multiple connect behavior.

## Additional context

Add any other context or screenshots.
