### PR TITLE
fix: Do not supress callback exceptions

### DIFF
--- a/realtime/_async/client.py
+++ b/realtime/_async/client.py
@@ -245,6 +245,8 @@ class AsyncRealtimeClient:
 
             except websockets.exceptions.ConnectionClosedError as e:
                 await self._on_connect_error(e)
+            except websockets.exceptions.ConnectionClosedOK as e:
+                pass
 
     def channel(
         self, topic: str, params: Optional[RealtimeChannelOptions] = None
@@ -348,6 +350,8 @@ class AsyncRealtimeClient:
                 await self._ws_connection.send(message)
             except websockets.exceptions.ConnectionClosedError as e:
                 await self._on_connect_error(e)
+            except websockets.exceptions.ConnectionClosedOK:
+                pass
 
         if self.is_connected:
             await send_message()

--- a/realtime/_async/client.py
+++ b/realtime/_async/client.py
@@ -10,6 +10,7 @@ import websockets
 from websockets import connect
 from websockets.client import ClientProtocol
 
+from ..exceptions import NotConnectedError
 from ..message import Message
 from ..transformers import http_endpoint_url
 from ..types import (
@@ -21,7 +22,6 @@ from ..types import (
 )
 from ..utils import is_ws_url
 from .channel import AsyncRealtimeChannel, RealtimeChannelOptions
-from ..exceptions import NotConnectedError
 
 
 def deprecated(func: Callable) -> Callable:

--- a/realtime/_async/client.py
+++ b/realtime/_async/client.py
@@ -187,7 +187,9 @@ class AsyncRealtimeClient:
         self._heartbeat_task = asyncio.create_task(self._heartbeat())
         await self._flush_send_buffer()
 
-    async def _on_connect_error(self, e: websockets.exceptions.ConnectionClosedError) -> None:
+    async def _on_connect_error(
+        self, e: websockets.exceptions.ConnectionClosedError
+    ) -> None:
         logger.error(
             f"WebSocket connection closed with code: {e.code}, reason: {e.reason}"
         )

--- a/realtime/exceptions.py
+++ b/realtime/exceptions.py
@@ -7,7 +7,7 @@ class NotConnectedError(Exception):
         self.offending_func_name: str = func_name
 
     def __str__(self):
-        return f"A WS connection has not been established. Ensure you call RealtimeClient.connect() before calling RealtimeClient.{self.offending_func_name}()"
+        return f"A WS connection has not been established. Ensure you call AsyncRealtimeClient.connect() before calling AsyncRealtimeClient.{self.offending_func_name}()"
 
 
 class AuthorizationError(Exception):


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fix #331 by catching only `websockets.exceptions.ConnectionClosedError` inside `_listen`, `send` and `_heartbeat`, re-raising any other errors that are raised from these calls.

## What is the current behavior?

Errors thrown from calling any of the callbacks are not shown to the user due to `_listen` suppressing them. The user is only able to see it if they have `logging` set

## What is the new behavior?

Any error not related to the websocket connection is ignored and subsequently shown to the user.

## Additional context

`send` and  `_heartbeat` can only ever raise `ConnectionClosedError`, so this should effectively be a no-op for those, however, `_listen` may raise any arbitrary exception, given that it calls callbacks. Still, `_listen` is spawned as a background thread, which means that any errors raised from it will not immediately be raised to the user; instead, they're printed exactly when the task is freed from memory, and given that `AsyncRealtimeClient` holds a handler to that task indefinitely, it will be printed only when the client is freed. This is a strong reason for switching for an asynchronous iterator approach in the future (`async for event in client`), instead of a callback approach, as control flow is much easier to handle.

Still, this does not represent a regression in public interface, as exceptions in the callback currently  also stop the `_listen` background task forever, as currently `AsyncRealtimeClient._on_connect_error` only tries to reconnect if the exception inherits from `ConnectionClosedError`.