### PR TITLE
feat: validate server message

### DIFF
--- a/realtime/_async/channel.py
+++ b/realtime/_async/channel.py
@@ -5,23 +5,49 @@ import json
 import logging
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Mapping, Optional
 
+from typing_extensions import assert_never
+
 from realtime.types import (
-    Binding,
+    BroadcastCallback,
+    BroadcastPayload,
     Callback,
     ChannelEvents,
     ChannelStates,
+    PostgresChangesCallback,
+    PostgresChangesData,
+    PresenceOnJoinCallback,
+    PresenceOnLeaveCallback,
+    RealtimeAcknowledgementStatus,
+    RealtimeChannelBroadcastConfig,
+    RealtimeChannelConfig,
     RealtimeChannelOptions,
+    RealtimeChannelPresenceConfig,
     RealtimePostgresChangesListenEvent,
     RealtimePresenceState,
     RealtimeSubscribeStates,
 )
 
-from ..message import Message
+from ..message import (
+    BroadcastMessage,
+    ChannelCloseMessage,
+    ChannelErrorMessage,
+    HeartbeatMessage,
+    Message,
+    PostgresChangesMessage,
+    PostgresChangesPayload,
+    PostgresRowChange,
+    PresenceDiffMessage,
+    PresenceStateMessage,
+    ReplyMessage,
+    ReplyPostgresChanges,
+    ServerMessage,
+    SuccessReplyMessage,
+    SuccessSystemPayload,
+    SystemMessage,
+)
 from ..transformers import http_endpoint_url
 from .presence import (
     AsyncRealtimePresence,
-    PresenceOnJoinCallback,
-    PresenceOnLeaveCallback,
 )
 from .push import AsyncPush
 from .timer import AsyncTimer
@@ -64,30 +90,36 @@ class AsyncRealtimeChannel:
                 }
             }
         )
-
         self.topic = topic
         self._joined_once = False
-        self.bindings: dict[str, list[Binding]] = {}
-        self.presence = AsyncRealtimePresence(self)
+        self.presence: AsyncRealtimePresence = AsyncRealtimePresence()
         self.state = ChannelStates.CLOSED
         self._push_buffer: list[AsyncPush] = []
         self.timeout = self.socket.timeout
 
         self.join_push: AsyncPush = AsyncPush(self, ChannelEvents.join, self.params)
+        self.messages_waiting_for_ack: dict[str, AsyncPush] = {}
+        self.broadcast_callbacks: list[BroadcastCallback] = []
+        self.system_callbacks: list[Callable[[SuccessSystemPayload], None]] = []
+        self.postgres_changes_callbacks: list[PostgresChangesCallback] = []
+        self.subscribe_callback: Optional[
+            Callable[[RealtimeSubscribeStates, Optional[Exception]], None]
+        ] = None
+
         self.rejoin_timer = AsyncTimer(
             self._rejoin_until_connected, lambda tries: 2**tries
         )
 
         self.broadcast_endpoint_url = self._broadcast_endpoint_url()
 
-        def on_join_push_ok(payload: Dict[str, Any], *args):
+        def on_join_push_ok(payload: ReplyPostgresChanges):
             self.state = ChannelStates.JOINED
             self.rejoin_timer.reset()
             for push in self._push_buffer:
                 asyncio.create_task(push.send())
             self._push_buffer = []
 
-        def on_join_push_timeout(*args):
+        def on_join_push_timeout():
             if not self.is_joining:
                 return
 
@@ -95,32 +127,23 @@ class AsyncRealtimeChannel:
             self.state = ChannelStates.ERRORED
             self.rejoin_timer.schedule_timeout()
 
-        self.join_push.receive("ok", on_join_push_ok).receive(
-            "timeout", on_join_push_timeout
-        )
+        self.join_push.receive(
+            RealtimeAcknowledgementStatus.Ok, on_join_push_ok
+        ).receive(RealtimeAcknowledgementStatus.Timeout, on_join_push_timeout)
 
-        def on_close(*args):
-            logger.info(f"channel {self.topic} closed")
-            self.rejoin_timer.reset()
-            self.state = ChannelStates.CLOSED
-            self.socket._remove_channel(self)
+    def on_close(self):
+        logger.info(f"channel {self.topic} closed")
+        self.rejoin_timer.reset()
+        self.state = ChannelStates.CLOSED
+        self.socket._remove_channel(self)
 
-        def on_error(payload, *args):
-            if self.is_leaving or self.is_closed:
-                return
+    def on_error(self, payload: dict[str, Any]):
+        if self.is_leaving or self.is_closed:
+            return
 
-            logger.info(f"channel {self.topic} error: {payload}")
-            self.state = ChannelStates.ERRORED
-            self.rejoin_timer.schedule_timeout()
-
-        self._on("close", on_close)
-        self._on("error", on_error)
-
-        def on_reply(payload: Dict[str, Any], ref: Optional[str]):
-            if ref:
-                self._trigger(self._reply_event_name(ref), payload)
-
-        self._on(ChannelEvents.reply, on_reply)
+        logger.info(f"channel {self.topic} error: {payload}")
+        self.state = ChannelStates.ERRORED
+        self.rejoin_timer.schedule_timeout()
 
     # Properties
     @property
@@ -142,10 +165,6 @@ class AsyncRealtimeChannel:
     @property
     def is_joined(self):
         return self.state == ChannelStates.JOINED
-
-    @property
-    def join_ref(self):
-        return self.join_push.ref
 
     # Core channel methods
     async def subscribe(
@@ -170,9 +189,9 @@ class AsyncRealtimeChannel:
                 "Tried to subscribe multiple times. 'subscribe' can only be called a single time per channel instance"
             )
         else:
-            config = self.params.get("config", {})
-            broadcast = config.get("broadcast", {})
-            presence = config.get("presence", {})
+            config: RealtimeChannelConfig = self.params["config"]
+            broadcast = config.get("broadcast")
+            presence = config.get("presence")
             private = config.get("private", False)
 
             config_payload: Dict[str, Any] = {
@@ -180,12 +199,9 @@ class AsyncRealtimeChannel:
                     "broadcast": broadcast,
                     "presence": presence,
                     "private": private,
-                    "postgres_changes": list(
-                        map(
-                            lambda x: x.filter,
-                            self.bindings.get("postgres_changes", []),
-                        )
-                    ),
+                    "postgres_changes": [
+                        c.binding_filter for c in self.postgres_changes_callbacks
+                    ],
                 }
             }
 
@@ -195,53 +211,42 @@ class AsyncRealtimeChannel:
             self.join_push.update_payload(config_payload)
             self._joined_once = True
 
-            def on_join_push_ok(payload: Dict[str, Any]):
-                server_postgres_changes: List[Dict[str, Any]] = payload.get(
-                    "postgres_changes", []
-                )
+            def on_join_push_ok(payload: ReplyPostgresChanges):
+                server_postgres_changes = payload.postgres_changes
 
-                if len(server_postgres_changes) == 0:
-                    callback and callback(RealtimeSubscribeStates.SUBSCRIBED, None)
-                    return
-
-                client_postgres_changes = self.bindings.get("postgres_changes", [])
                 new_postgres_bindings = []
 
-                bindings_len = len(client_postgres_changes)
-
-                for i in range(bindings_len):
-                    client_binding = client_postgres_changes[i]
-                    event = client_binding.filter.get("event")
-                    schema = client_binding.filter.get("schema")
-                    table = client_binding.filter.get("table")
-                    filter = client_binding.filter.get("filter")
-
-                    server_binding = (
-                        server_postgres_changes[i]
-                        if i < len(server_postgres_changes)
-                        else None
-                    )
-
-                    if (
-                        server_binding
-                        and server_binding.get("event") == event
-                        and server_binding.get("schema") == schema
-                        and server_binding.get("table") == table
-                        and server_binding.get("filter") == filter
+                if server_postgres_changes:
+                    for i, postgres_callback in enumerate(
+                        self.postgres_changes_callbacks
                     ):
-                        client_binding.id = server_binding.get("id")
-                        new_postgres_bindings.append(client_binding)
-                    else:
-                        asyncio.create_task(self.unsubscribe())
-                        callback and callback(
-                            RealtimeSubscribeStates.CHANNEL_ERROR,
-                            Exception(
-                                "mismatch between server and client bindings for postgres changes"
-                            ),
+                        server_binding: Optional[PostgresRowChange] = (
+                            server_postgres_changes[i]
+                            if i < len(server_postgres_changes)
+                            else None
                         )
-                        return
+                        logger.info(f"{server_binding}, {postgres_callback}")
 
-                self.bindings["postgres_changes"] = new_postgres_bindings
+                        if (
+                            server_binding
+                            and server_binding.events == postgres_callback.event
+                            and server_binding.schema_ == postgres_callback.schema
+                            and server_binding.table == postgres_callback.table
+                            and server_binding.filter == postgres_callback.filter
+                        ):
+                            postgres_callback.id = server_binding.id
+                            new_postgres_bindings.append(postgres_callback)
+                        else:
+                            asyncio.create_task(self.unsubscribe())
+                            callback and callback(
+                                RealtimeSubscribeStates.CHANNEL_ERROR,
+                                Exception(
+                                    "mismatch between server and client bindings for postgres changes"
+                                ),
+                            )
+                            return
+
+                self.postgres_changes_callbacks = new_postgres_bindings
                 callback and callback(RealtimeSubscribeStates.SUBSCRIBED, None)
 
             def on_join_push_error(payload: Dict[str, Any]):
@@ -253,9 +258,11 @@ class AsyncRealtimeChannel:
             def on_join_push_timeout(*args):
                 callback and callback(RealtimeSubscribeStates.TIMED_OUT, None)
 
-            self.join_push.receive("ok", on_join_push_ok).receive(
-                "error", on_join_push_error
-            ).receive("timeout", on_join_push_timeout)
+            self.join_push.receive(
+                RealtimeAcknowledgementStatus.Ok, on_join_push_ok
+            ).receive(RealtimeAcknowledgementStatus.Error, on_join_push_error).receive(
+                RealtimeAcknowledgementStatus.Timeout, on_join_push_timeout
+            )
 
             await self._rejoin()
 
@@ -273,15 +280,13 @@ class AsyncRealtimeChannel:
 
         def _close(*args) -> None:
             logger.info(f"channel {self.topic} leave")
-            self._trigger(ChannelEvents.close, {})
+            self.on_close()
 
         leave_push = AsyncPush(self, ChannelEvents.leave, {})
-        leave_push.receive("ok", _close).receive("timeout", _close)
-
+        leave_push.receive(RealtimeAcknowledgementStatus.Ok, _close).receive(
+            RealtimeAcknowledgementStatus.Error, _close
+        )
         await leave_push.send()
-
-        if not self._can_push():
-            leave_push.trigger("ok", {})
 
     async def push(
         self, event: str, payload: Dict[str, Any], timeout: Optional[int] = None
@@ -305,6 +310,7 @@ class AsyncRealtimeChannel:
         push = AsyncPush(self, event, payload, timeout)
         if self._can_push():
             await push.send()
+            assert push.ref is not None, "Sent AsyncPush should have a ref"
         else:
             push.start_timeout()
             self._push_buffer.append(push)
@@ -317,64 +323,32 @@ class AsyncRealtimeChannel:
 
         :return: Channel
         """
-        try:
-            message = Message(
-                topic=self.topic,
-                event=ChannelEvents.join,
-                payload={"config": self.params},
-                ref=None,
-            )
-            await self.socket.send(message)
-            return self
-        except Exception as e:
-            print(e)
-            return self
+        config = self.params["config"]
+        broadcast = config.get("broadcast")
+        presence = config.get("presence")
+        private = config.get("private", False)
 
-    # Event handling methods
-    def _on(
-        self,
-        type: str,
-        callback: Callback[[Dict[str, Any], Optional[str]], None],
-        filter: Optional[Dict[str, Any]] = None,
-    ) -> AsyncRealtimeChannel:
-        """
-        Set up a listener for a specific event.
-
-        :param type: The type of the event to listen for.
-        :param filter: Additional parameters for the event.
-        :param callback: The callback function to execute when the event is received.
-        :return: The Channel instance for method chaining.
-        """
-
-        type_lowercase = type.lower()
-        binding = Binding(type=type_lowercase, filter=filter or {}, callback=callback)
-        self.bindings.setdefault(type_lowercase, []).append(binding)
-
-        return self
-
-    def _off(self, type: str, filter: Dict[str, Any]) -> AsyncRealtimeChannel:
-        """
-        Remove a listener for a specific event type and filter.
-
-        :param type: The type of the event to remove the listener for.
-        :param filter: The filter associated with the listener to remove.
-        :return: The Channel instance for method chaining.
-
-        This method removes all bindings for the specified event type that match
-        the given filter. If no matching bindings are found, the method does nothing.
-        """
-        type_lowercase = type.lower()
-
-        if type_lowercase in self.bindings:
-            self.bindings[type_lowercase] = [
-                binding
-                for binding in self.bindings[type_lowercase]
-                if binding.filter != filter
-            ]
+        config_payload: Dict[str, Any] = {
+            "config": {
+                "broadcast": broadcast,
+                "presence": presence,
+                "private": private,
+                "postgres_changes": [
+                    c.binding_filter for c in self.postgres_changes_callbacks
+                ],
+            }
+        }
+        message = Message(
+            topic=self.topic,
+            event=ChannelEvents.join,
+            payload={"config": config_payload},
+            ref=self.socket._make_ref(),
+        )
+        await self.socket.send(message)
         return self
 
     def on_broadcast(
-        self, event: str, callback: Callable[[Dict[str, Any]], None]
+        self, event: str, callback: Callable[[BroadcastPayload], None]
     ) -> AsyncRealtimeChannel:
         """
         Set up a listener for a specific broadcast event.
@@ -383,16 +357,15 @@ class AsyncRealtimeChannel:
         :param callback: Function called with the payload when a matching broadcast is received
         :return: The Channel instance for method chaining
         """
-        return self._on(
-            "broadcast",
-            filter={"event": event},
-            callback=lambda payload, _: callback(payload),
+        self.broadcast_callbacks.append(
+            BroadcastCallback(callback=callback, event=event)
         )
+        return self
 
     def on_postgres_changes(
         self,
         event: RealtimePostgresChangesListenEvent,
-        callback: Callable[[Dict[str, Any]], None],
+        callback: Callable[[PostgresChangesPayload], None],
         table: Optional[str] = None,
         schema: Optional[str] = None,
         filter: Optional[str] = None,
@@ -407,22 +380,14 @@ class AsyncRealtimeChannel:
         :param filter: Optional filter string to apply
         :return: The Channel instance for method chaining
         """
-
-        binding_filter = {"event": event, "table": table}
-        if schema:
-            binding_filter["schema"] = schema
-
-        if filter:
-            binding_filter["filter"] = filter
-
-        return self._on(
-            "postgres_changes",
-            filter=binding_filter,
-            callback=lambda payload, _: callback(payload),
+        callback = PostgresChangesCallback(
+            callback=callback, event=event, table=table, schema=schema, filter=filter
         )
+        self.postgres_changes_callbacks.append(callback)
+        return self
 
     def on_system(
-        self, callback: Callable[[Dict[str, Any]], None]
+        self, callback: Callable[[SuccessSystemPayload], None]
     ) -> AsyncRealtimeChannel:
         """
         Set up a listener for system events.
@@ -430,7 +395,8 @@ class AsyncRealtimeChannel:
         :param callback: The callback function to execute when a system event is received.
         :return: The Channel instance for method chaining.
         """
-        return self._on("system", callback=lambda payload, _: callback(payload))
+        self.system_callbacks.append(callback)
+        return self
 
     # Presence methods
     async def track(self, user_status: Dict[str, Any]) -> None:
@@ -519,62 +485,45 @@ class AsyncRealtimeChannel:
     async def send_presence(self, event: str, data: Any) -> None:
         await self.push(ChannelEvents.presence, {"event": event, "payload": data})
 
-    def _trigger(self, type: str, payload: Dict[str, Any], ref: Optional[str] = None):
-        type_lowercase = type.lower()
-        events = [
-            ChannelEvents.close,
-            ChannelEvents.error,
-            ChannelEvents.leave,
-            ChannelEvents.join,
-        ]
-
-        if ref is not None and type_lowercase in events and ref != self.join_push.ref:
+    def _handle_message(self, message: ServerMessage):
+        logger.info(f"{self.topic} : {message}")
+        if isinstance(message, SystemMessage):
+            if isinstance(message.payload, SuccessSystemPayload):
+                for callback in self.system_callbacks:
+                    callback(message.payload)
+            else:
+                self.on_error(dict(message.payload))
+        elif isinstance(message, ReplyMessage):
+            reply_payload = message.payload
+            if message.ref and (push := self.messages_waiting_for_ack.pop(message.ref)):
+                if reply_payload.status == "ok":
+                    push.trigger(
+                        RealtimeAcknowledgementStatus.Ok, reply_payload.response
+                    )
+                else:
+                    push.trigger(
+                        RealtimeAcknowledgementStatus.Error, reply_payload.response
+                    )
+        elif isinstance(message, BroadcastMessage):
+            broadcast_payload = message.payload
+            for broadcast_callback in self.broadcast_callbacks:
+                broadcast_callback(broadcast_payload)
+        elif isinstance(message, PresenceStateMessage):
+            self.presence._on_state_event(message.payload)
+        elif isinstance(message, PresenceDiffMessage):
+            self.presence._on_diff_event(message.payload)
+        elif isinstance(message, PostgresChangesMessage):
+            payload = message.payload
+            for postgres_callback in self.postgres_changes_callbacks:
+                postgres_callback(payload)
+        elif isinstance(message, ChannelErrorMessage):
+            self.on_error(message.payload)
+        elif isinstance(message, ChannelCloseMessage):
+            self.on_close()
+        elif isinstance(message, HeartbeatMessage):  # do nothing
             return
-
-        if type_lowercase in ["insert", "update", "delete"]:
-            postgres_changes = filter(
-                lambda binding: binding.filter.get("event", "").lower()
-                in [type_lowercase, "*"],
-                self.bindings.get("postgres_changes", []),
-            )
-            for binding in postgres_changes:
-                binding.callback(payload, ref)
         else:
-            bindings = self.bindings.get(type_lowercase, [])
-            for binding in bindings:
-                if type_lowercase in ["broadcast", "postgres_changes", "presence"]:
-                    bind_event = (
-                        binding.filter.get("event", "").lower()
-                        if binding.filter.get("event")
-                        else None
-                    )
-                    payload_event = (
-                        payload.get("event", "").lower()
-                        if payload and payload.get("event")
-                        else None
-                    )
-
-                    if hasattr(binding, "id") and binding.id is not None:
-                        bind_id = binding.id
-                        data_type = (
-                            payload.get("data", {}).get("type", "").lower()
-                            if payload and payload.get("data", {}).get("type")
-                            else None
-                        )
-
-                        if (
-                            bind_id
-                            and bind_id in payload.get("ids", [])
-                            and (bind_event == data_type or bind_event == "*")
-                        ):
-                            binding.callback(payload, ref)
-                    elif bind_event in [payload_event, "*"]:
-                        binding.callback(payload, ref)
-                elif binding.type == type_lowercase:
-                    binding.callback(payload, ref)
-
-    def _reply_event_name(self, ref: str) -> str:
-        return f"chan_reply_{ref}"
+            assert_never(message)
 
     async def _rejoin_until_connected(self):
         self.rejoin_timer.schedule_timeout()

--- a/realtime/_async/client.py
+++ b/realtime/_async/client.py
@@ -11,7 +11,7 @@ from websockets import connect
 from websockets.asyncio.client import ClientConnection
 
 from ..exceptions import NotConnectedError
-from ..message import Message
+from ..message import Message, ServerMessageAdapter
 from ..transformers import http_endpoint_url
 from ..types import (
     DEFAULT_HEARTBEAT_INTERVAL,
@@ -99,6 +99,9 @@ class AsyncRealtimeClient:
             async for msg in self._ws_connection:
                 logger.info(f"receive: {msg!r}")
 
+                print(msg)
+                server_msg = ServerMessageAdapter.validate_json(msg)
+                print(server_msg)
                 message = Message.model_validate_json(msg)
                 channel = self.channels.get(message.topic)
 

--- a/realtime/_async/client.py
+++ b/realtime/_async/client.py
@@ -7,6 +7,7 @@ from typing import Any, Callable, Dict, List, Optional, Union
 from urllib.parse import urlencode, urlparse, urlunparse
 
 import websockets
+from pydantic import ValidationError
 from websockets import connect
 from websockets.asyncio.client import ClientConnection
 
@@ -99,16 +100,14 @@ class AsyncRealtimeClient:
             async for msg in self._ws_connection:
                 logger.info(f"receive: {msg!r}")
 
-                print(msg)
-                server_msg = ServerMessageAdapter.validate_json(msg)
-                print(server_msg)
-                message = Message.model_validate_json(msg)
-                channel = self.channels.get(message.topic)
-
-                if channel:
-                    channel._trigger(
-                        message.event, dict(**message.payload), message.ref
-                    )
+                try:
+                    message = ServerMessageAdapter.validate_json(msg)
+                except ValidationError as e:
+                    logger.error(f"Unrecognized message format {msg!r}\n{e}")
+                    continue
+                logger.info(f"parsed message as {message}")
+                if channel := self.channels.get(message.topic):
+                    channel._handle_message(message)
         except websockets.exceptions.ConnectionClosedError as e:
             await self._on_connect_error(e)
 

--- a/realtime/_async/push.py
+++ b/realtime/_async/push.py
@@ -2,10 +2,12 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from typing import TYPE_CHECKING, Any, Dict, List, Mapping, Optional
+from typing import TYPE_CHECKING, Any, Dict, List, Literal, Mapping, Optional
 
-from ..message import Message
-from ..types import DEFAULT_TIMEOUT, Callback, _Hook
+from typing_extensions import assert_never, overload
+
+from ..message import Message, ReplyPostgresChanges
+from ..types import DEFAULT_TIMEOUT, Callback, RealtimeAcknowledgementStatus, _Hook
 
 if TYPE_CHECKING:
     from .channel import AsyncRealtimeChannel
@@ -27,23 +29,30 @@ class AsyncPush:
         self.timeout = timeout
         self.rec_hooks: List[_Hook] = []
         self.ref: Optional[str] = None
-        self.ref_event: Optional[str] = None
-        self.received_resp: Optional[Dict[str, Any]] = None
+        self.received_resp: Optional[
+            tuple[RealtimeAcknowledgementStatus, Dict[str, Any]]
+        ] = None
         self.sent = False
         self.timeout_task: Optional[asyncio.Task] = None
+        self.ok_callbacks: list[Callback[[ReplyPostgresChanges], None]] = []
+        self.error_callbacks: list[Callback[[Dict[str, Any]], None]] = []
+        self.timeout_callbacks: list[Callback[[], None]] = []
 
     async def resend(self):
-        self._cancel_ref_event()
-        self.ref = ""
-        self.ref_event = None
+        self.ref = None
         self.received_resp = None
         self.sent = False
         await self.send()
 
     async def send(self):
-        if self._has_received("timeout"):
+        if (
+            self.received_resp
+            and self.received_resp[0] == RealtimeAcknowledgementStatus.Timeout
+        ):
             return
 
+        self.ref = self.channel.socket._make_ref()
+        self.channel.messages_waiting_for_ack[self.ref] = self
         self.start_timeout()
         self.sent = True
 
@@ -52,61 +61,93 @@ class AsyncPush:
             event=self.event,
             ref=self.ref,
             payload=self.payload,
-            join_ref=self.channel.join_push.ref,
         )
         await self.channel.socket.send(message)
 
     def update_payload(self, payload: Dict[str, Any]):
         self.payload = {**self.payload, **payload}
 
+    @overload
     def receive(
-        self, status: str, callback: Callback[[Dict[str, Any]], None]
-    ) -> AsyncPush:
-        if self.received_resp and self.received_resp.get("status") == status:
-            callback(self.received_resp)
+        self,
+        status: Literal[RealtimeAcknowledgementStatus.Ok],
+        callback: Callback[[ReplyPostgresChanges], None],
+    ) -> AsyncPush: ...
+    @overload
+    def receive(
+        self,
+        status: Literal[RealtimeAcknowledgementStatus.Error],
+        callback: Callback[[Dict[str, Any]], None],
+    ) -> AsyncPush: ...
 
-        self.rec_hooks.append(_Hook(status, callback))
+    @overload
+    def receive(
+        self,
+        status: Literal[RealtimeAcknowledgementStatus.Timeout],
+        callback: Callback[[], None],
+    ) -> AsyncPush: ...
+
+    def receive(self, status, callback) -> AsyncPush:
+        if (received := self.received_resp) and received[0] == status:
+            callback(received[1])
+        else:
+            if status == RealtimeAcknowledgementStatus.Ok:
+                self.ok_callbacks.append(callback)
+            elif status == RealtimeAcknowledgementStatus.Error:
+                self.error_callbacks.append(callback)
+            elif status == RealtimeAcknowledgementStatus.Timeout:
+                self.timeout_callbacks.append(callback)
+            else:
+                assert_never(status)
         return self
 
     def start_timeout(self):
         if self.timeout_task:
             return
 
-        self.ref = self.channel.socket._make_ref()
-        current_event = self.channel._reply_event_name(self.ref)
-        self.ref_event = current_event
-
-        def on_reply(payload: Dict[str, Any], _ref: Optional[str]):
-            self._cancel_ref_event()
-            self._cancel_timeout()
-            self.received_resp = payload
-            self._match_receive(**payload)
-
-        self.channel._on(self.ref_event, on_reply)
-
         async def timeout(self):
             await asyncio.sleep(self.timeout)
-            self.trigger("timeout", {})
+            self.trigger(RealtimeAcknowledgementStatus.Timeout, {})
+            if self.ref and self.ref in self.channel.messages_waiting_for_ack:
+                del self.channel.messages_waiting_for_ack[self.ref]
 
         self.timeout_task = asyncio.create_task(timeout(self))
 
-    def trigger(self, status: str, response: dict[str, Any]):
-        if self.ref_event:
-            payload = {
-                "status": status,
-                "response": response,
-            }
-            self.channel._trigger(self.ref_event, payload)
+    @overload
+    def trigger(
+        self,
+        status: Literal[RealtimeAcknowledgementStatus.Ok],
+        response: ReplyPostgresChanges,
+    ): ...
+    @overload
+    def trigger(
+        self,
+        status: Literal[RealtimeAcknowledgementStatus.Error],
+        response: Dict[str, Any],
+    ): ...
+    @overload
+    def trigger(
+        self,
+        status: Literal[RealtimeAcknowledgementStatus.Timeout],
+        response: Dict[str, Any],
+    ): ...
+
+    def trigger(self, status: RealtimeAcknowledgementStatus, response) -> None:
+        self.received_resp = (status, response)
+        if status == RealtimeAcknowledgementStatus.Ok:
+            for ok_callback in self.ok_callbacks:
+                ok_callback(response)
+        elif status == RealtimeAcknowledgementStatus.Error:
+            for error_callback in self.error_callbacks:
+                error_callback(response)
+        elif status == RealtimeAcknowledgementStatus.Timeout:
+            for timeout_callback in self.timeout_callbacks:
+                timeout_callback()
+        else:
+            assert_never(status)
 
     def destroy(self):
-        self._cancel_ref_event()
         self._cancel_timeout()
-
-    def _cancel_ref_event(self):
-        if not self.ref_event:
-            return
-
-        self.channel._off(self.ref_event, {})
 
     def _cancel_timeout(self):
         if not self.timeout_task:
@@ -114,13 +155,3 @@ class AsyncPush:
 
         self.timeout_task.cancel()
         self.timeout_task = None
-
-    def _match_receive(self, status: str, response: dict[str, Any]):
-        for hook in self.rec_hooks:
-            if hook.status == status:
-                hook.callback(response)
-
-    def _has_received(self, status: str) -> bool:
-        if self.received_resp and self.received_resp.get("status") == status:
-            return True
-        return False

--- a/realtime/message.py
+++ b/realtime/message.py
@@ -1,15 +1,140 @@
-from typing import Any, Mapping, Optional
+from typing import Any, List, Literal, Mapping, Optional, Union
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field, TypeAdapter
+from typing_extensions import TypeAlias
+
+from .types import (
+    ChannelEvents,
+    PresenceDiff,
+    RealtimeChannelOptions,
+    RealtimePostgresChangesListenEvent,
+)
 
 
-class Message(BaseModel):
-    """
-    Dataclass abstraction for message
-    """
-
-    event: str
-    payload: Mapping[str, Any]
+class ConnectionMessage(BaseModel):
+    event: Literal[ChannelEvents.join]
     topic: str
-    ref: Optional[str] = None
-    join_ref: Optional[str] = None
+    ref: str
+    payload: RealtimeChannelOptions
+
+
+class PostgresRowChange(BaseModel):
+    id: int
+    event: RealtimePostgresChangesListenEvent
+    _schema: str = Field(alias="schema")
+    table: str
+    filter: str
+
+
+class ConnectionReplyPostgresChanges(BaseModel):
+    postgres_changes: List[PostgresRowChange]
+
+
+class ConnectionReplyPayload(BaseModel):
+    response: ConnectionReplyPostgresChanges
+    status: Literal["ok", "error"]
+
+
+class ConnectionReplyMessage(BaseModel):
+    event: Literal[ChannelEvents.reply]
+    topic: str
+    payload: ConnectionReplyPayload
+    ref: str
+
+
+class SystemPayload(BaseModel):
+    channel: str
+    extension: Literal["postgres_changes"]
+    message: Literal["Subscribed to PostgreSQL", "Subscribing to PostgreSQL failed"]
+    status: Literal["ok", "error"]
+
+
+class SystemMessage(BaseModel):
+    event: Literal[ChannelEvents.system]
+    topic: str
+    payload: SystemPayload
+    ref: Literal[None]
+
+
+class HeartbeatPayload(BaseModel):
+    pass
+
+
+class HeartbeatMessage(BaseModel):
+    event: Literal[ChannelEvents.heartbeat]
+    topic: Literal["phoenix"]
+    ref: str
+    payload: HeartbeatPayload
+
+
+class AccessTokenPayload(BaseModel):
+    access_token: str
+
+
+class AccessTokenMessage(BaseModel):
+    event: Literal[ChannelEvents.access_token]
+    topic: str
+    payload: AccessTokenPayload
+
+
+class PostgresChangesData(BaseModel):
+    _schema: str = Field(alias="schema")
+    table: str
+    commit_timestamp: str
+    eventType: RealtimePostgresChangesListenEvent
+    errors: Optional[str]
+    new: dict[str, Union[bool, int, str, None]]
+    old: dict[str, Union[int, str]]
+
+
+class PostgresChangesPayload(BaseModel):
+    data: PostgresChangesData
+    ids: List[int]
+
+
+class PostgresChangesMessage(BaseModel):
+    event: Literal[ChannelEvents.postgres_changes]
+    topic: str
+    payload: PostgresChangesPayload
+    ref: Literal[None]
+
+
+class BroadcastMessage(BaseModel):
+    event: Literal[ChannelEvents.broadcast]
+    topic: str
+    payload: dict[str, Any]
+    ref: Literal[None]
+
+
+class PresenceMessage(BaseModel):
+    event: Literal[ChannelEvents.presence]
+    topic: str
+    payload: dict[str, Any]
+    ref: Literal[None]
+
+
+class PresenceStateMessage(BaseModel):
+    event: Literal[ChannelEvents.presence_state]
+    topic: str
+    payload: dict[str, Any]
+    ref: Literal[None]
+
+
+class PresenceDiffMessage(BaseModel):
+    event: Literal[ChannelEvents.presence_diff]
+    topic: str
+    payload: PresenceDiff
+    ref: Literal[None]
+
+
+ServerMessage: TypeAlias = Union[
+    ConnectionReplyMessage,
+    HeartbeatMessage,
+    BroadcastMessage,
+    PresenceStateMessage,
+    PresenceDiffMessage,
+]
+ServerMessageAdapter = TypeAdapter(ServerMessage)
+ClientMessage: TypeAlias = Union[
+    ConnectionMessage, HeartbeatMessage, BroadcastMessage, PresenceMessage
+]

--- a/realtime/types.py
+++ b/realtime/types.py
@@ -33,6 +33,10 @@ class ChannelEvents(str, Enum):
     access_token = "access_token"
     broadcast = "broadcast"
     presence = "presence"
+    presence_state = "presence_state"
+    presence_diff = "presence_diff"
+    system = "system"
+    postgres_changes = "postgres_changes"
 
 
 class ChannelStates(str, Enum):

--- a/realtime/types.py
+++ b/realtime/types.py
@@ -1,10 +1,18 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
 from enum import Enum
-from typing import Any, Callable, Dict, List, Literal, Optional, TypedDict, TypeVar
+from typing import Any, Callable, Dict, List, Literal, Optional, TypeVar
 
-from pydantic import BaseModel
-from typing_extensions import ParamSpec, TypeAlias
+from pydantic import BaseModel, ConfigDict, Field, with_config
+from typing_extensions import (
+    Generic,
+    NotRequired,
+    ParamSpec,
+    Required,
+    TypeAlias,
+    TypedDict,
+)
 
 # Constants
 DEFAULT_TIMEOUT = 10
@@ -61,23 +69,84 @@ class RealtimePresenceListenEvents(str, Enum):
     LEAVE = "LEAVE"
 
 
+class RealtimeAcknowledgementStatus(str, Enum):
+    Ok = "ok"
+    Error = "error"
+    Timeout = "timeout"
+
+
 # Literals
-RealtimePostgresChangesListenEvent = Literal["*", "INSERT", "UPDATE", "DELETE"]
+class RealtimePostgresChangesListenEvent(str, Enum):
+    All = "*"
+    Insert = "INSERT"
+    Update = "UPDATE"
+    Delete = "DELETE"
 
 
-# Classes
-class Binding:
-    def __init__(
-        self,
-        type: str,
-        filter: Dict[str, Any],
-        callback: Callback[[Dict[str, Any], Optional[str]], None],
-        id: Optional[str] = None,
-    ):
-        self.type = type
-        self.filter = filter
-        self.callback = callback
-        self.id = id
+Payload = TypeVar("Payload")
+
+
+class PostgresChangesColumn(TypedDict):
+    name: str
+    type: str
+
+
+class PostgresChangesData(TypedDict):
+    schema: str
+    table: str
+    commit_timestamp: str
+    type: RealtimePostgresChangesListenEvent
+    errors: Optional[str]
+    columns: List[PostgresChangesColumn]
+    record: NotRequired[Optional[dict[str, Any]]]
+    old_record: NotRequired[dict[str, Any]]  # todo: improve this
+
+
+class PostgresChangesPayload(TypedDict):
+    data: PostgresChangesData
+    ids: List[int]
+
+
+class BroadcastPayload(TypedDict):
+    event: str
+    payload: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class BroadcastCallback:
+    callback: Callable[[BroadcastPayload], None]
+    event: str
+
+    def __call__(self, payload: BroadcastPayload) -> None:
+        if self.event == payload["event"]:
+            return self.callback(payload)
+
+
+@dataclass
+class PostgresChangesCallback:
+    callback: Callable[[PostgresChangesPayload], None]
+    event: RealtimePostgresChangesListenEvent
+    table: Optional[str]
+    schema: Optional[str]
+    filter: Optional[str]
+    id: Optional[int] = None
+
+    def __call__(self, payload: PostgresChangesPayload) -> None:
+        event_matches = (
+            self.event == payload["data"]["type"]
+            or self.event == RealtimePostgresChangesListenEvent.All
+        )
+        if self.id and self.id in payload["ids"] and event_matches:
+            return self.callback(payload)
+
+    @property
+    def binding_filter(self) -> dict[str, Optional[str]]:
+        binding = {"events": self.event, "table": self.table}
+        if self.schema:
+            binding["schema"] = self.schema
+        if self.filter:
+            binding["filter"] = self.filter
+        return binding
 
 
 class _Hook:
@@ -86,7 +155,8 @@ class _Hook:
         self.callback = callback
 
 
-class Presence(TypedDict, total=False):
+@with_config(ConfigDict(extra="allow"))
+class Presence(TypedDict):
     presence_ref: str
 
 
@@ -112,8 +182,8 @@ class RealtimeChannelPresenceConfig(TypedDict):
 
 
 class RealtimeChannelConfig(TypedDict):
-    broadcast: RealtimeChannelBroadcastConfig
-    presence: RealtimeChannelPresenceConfig
+    broadcast: Optional[RealtimeChannelBroadcastConfig]
+    presence: Optional[RealtimeChannelPresenceConfig]
     private: bool
 
 
@@ -121,41 +191,42 @@ class RealtimeChannelOptions(TypedDict):
     config: RealtimeChannelConfig
 
 
-class PresenceMeta(BaseModel, extra="allow"):
-    phx_ref: str
-    phx_ref_prev: Optional[str] = None
+@with_config(ConfigDict(extra="allow"))
+class PresenceMeta(TypedDict):
+    phx_ref: NotRequired[str]
+    phx_ref_prev: NotRequired[str]
 
 
-class RawPresenceStateEntry(BaseModel):
+class RawPresenceStateEntry(TypedDict):
     metas: List[PresenceMeta]
 
 
 # Custom types
-PresenceOnJoinCallback = Callable[[str, List[Any], List[Any]], None]
-PresenceOnLeaveCallback = Callable[[str, List[Any], List[Any]], None]
+PresenceOnJoinCallback = Callable[[str, List[Any], List[Presence]], None]
+PresenceOnLeaveCallback = Callable[[str, List[Any], List[Presence]], None]
 RealtimePresenceState = Dict[str, List[Presence]]
 RawPresenceState = Dict[str, RawPresenceStateEntry]
 
 
-class RawPresenceDiff(BaseModel):
+class RawPresenceDiff(TypedDict):
     joins: RawPresenceState
     leaves: RawPresenceState
 
 
-class PresenceDiff(BaseModel):
+class PresenceDiff(TypedDict):
     joins: RealtimePresenceState
     leaves: RealtimePresenceState
 
 
 # Specific payload types
-class RealtimePresenceJoinPayload(Dict[str, Any]):
+class RealtimePresenceJoinPayload(TypedDict):
     event: Literal[RealtimePresenceListenEvents.JOIN]
     key: str
     current_presences: List[Presence]
     new_presences: List[Presence]
 
 
-class RealtimePresenceLeavePayload(Dict[str, Any]):
+class RealtimePresenceLeavePayload(TypedDict):
     event: Literal[RealtimePresenceListenEvents.LEAVE]
     key: str
     current_presences: List[Presence]

--- a/realtime/types.py
+++ b/realtime/types.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from enum import Enum
 from typing import Any, Callable, Dict, List, Literal, Optional, TypedDict, TypeVar
 
+from pydantic import BaseModel
 from typing_extensions import ParamSpec, TypeAlias
 
 # Constants
@@ -120,12 +121,12 @@ class RealtimeChannelOptions(TypedDict):
     config: RealtimeChannelConfig
 
 
-class PresenceMeta(TypedDict, total=False):
+class PresenceMeta(BaseModel, extra="allow"):
     phx_ref: str
-    phx_ref_prev: Optional[str]
+    phx_ref_prev: Optional[str] = None
 
 
-class RawPresenceStateEntry(TypedDict):
+class RawPresenceStateEntry(BaseModel):
     metas: List[PresenceMeta]
 
 
@@ -136,12 +137,12 @@ RealtimePresenceState = Dict[str, List[Presence]]
 RawPresenceState = Dict[str, RawPresenceStateEntry]
 
 
-class RawPresenceDiff(TypedDict):
+class RawPresenceDiff(BaseModel):
     joins: RawPresenceState
     leaves: RawPresenceState
 
 
-class PresenceDiff(TypedDict):
+class PresenceDiff(BaseModel):
     joins: RealtimePresenceState
     leaves: RealtimePresenceState
 

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -9,7 +9,7 @@ from dotenv import load_dotenv
 
 from realtime import AsyncRealtimeChannel, AsyncRealtimeClient, RealtimeSubscribeStates
 from realtime.message import Message
-from realtime.types import DEFAULT_HEARTBEAT_INTERVAL, DEFAULT_TIMEOUT
+from realtime.types import DEFAULT_HEARTBEAT_INTERVAL, DEFAULT_TIMEOUT, ChannelEvents
 
 load_dotenv()
 
@@ -424,7 +424,7 @@ async def test_send_message_reconnection(socket: AsyncRealtimeClient):
     # Try to send a message - this should trigger reconnection
     message = Message(
         topic="test-channel",
-        event="test-event",
+        event=ChannelEvents.broadcast,
         payload={"test": "data"},
     )
     await socket.send(message)

--- a/tests/test_presence.py
+++ b/tests/test_presence.py
@@ -7,6 +7,7 @@ import pytest
 from dotenv import load_dotenv
 
 from realtime import AsyncRealtimeChannel, AsyncRealtimeClient, AsyncRealtimePresence
+from realtime.types import RawPresenceState
 
 load_dotenv()
 
@@ -110,7 +111,7 @@ async def test_presence(socket: AsyncRealtimeClient):
 
 
 def test_transform_state_raw_presence_state():
-    raw_state = {
+    raw_state: RawPresenceState = {
         "user1": {
             "metas": [
                 {"phx_ref": "ABC123", "user_id": "user1", "status": "online"},
@@ -136,44 +137,6 @@ def test_transform_state_raw_presence_state():
     }
 
     result = AsyncRealtimePresence._transform_state(raw_state)
-    assert result == expected_output
-
-
-def test_transform_state_already_transformed():
-    transformed_state = {
-        "user1": [{"presence_ref": "ABC123", "user_id": "user1", "status": "online"}],
-        "user2": [{"presence_ref": "GHI789", "user_id": "user2", "status": "offline"}],
-    }
-
-    result = AsyncRealtimePresence._transform_state(transformed_state)
-    assert result == transformed_state
-
-
-def test_transform_state_mixed_input():
-    mixed_state = {
-        "user1": {
-            "metas": [
-                {"phx_ref": "ABC123", "user_id": "user1", "status": "online"},
-                {
-                    "phx_ref": "DEF456",
-                    "phx_ref_prev": "ABC123",
-                    "user_id": "user1",
-                    "status": "away",
-                },
-            ]
-        },
-        "user2": [{"user_id": "user2", "status": "offline"}],
-    }
-
-    expected_output = {
-        "user1": [
-            {"presence_ref": "ABC123", "user_id": "user1", "status": "online"},
-            {"presence_ref": "DEF456", "user_id": "user1", "status": "away"},
-        ],
-        "user2": [{"user_id": "user2", "status": "offline"}],
-    }
-
-    result = AsyncRealtimePresence._transform_state(mixed_state)
     assert result == expected_output
 
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Validate messages according to realtime protocol specification.

## What is the current behavior?

The server receives an opaque `Message` object inside the main `_listen` loop that is then parsed inside the `AsyncRealtimeChannel._trigger` function, which also is responsible for dispatching callbacks. 

The same `_trigger` logic is also responsible for calling the callbacks for message acknowledgments, registered by `AsyncPush.receive`, by creating virtual events depending on the `AsyncPush` refs. This makes the function logic very hard to understand, and mixes multiple different use cases in the same callbacks.

## What is the new behavior?

First, introduce `ServerMessage` type that represent all possible messages that the server might send to a client, and use `pydantic`'s `TypeAdapter` to automatically parse and validate the payload types. 

Then, rename `_trigger` to `_handle_messages` to emphasize that it is only handling `ServerMessage`s. In order to handle message acks callbacks, introduce a new dictionary `AsyncRealtimeChannel.messages_waiting_for_ack` dictionary that saves the `AsyncPush`es, and save the callbacks inside the push objects themselves, which are called inside the `reply` handling logic.

## Additional context

This PR also has the added benefit of specifying the type annotations for each different callback, instead of making them all receive `Dict[str, Any]` like before. I also removed two tests related to presence state transform because they seemed to test  for behavior that does not seem to happen anywhere in the library, and seems to be inherited from the js implementation.
